### PR TITLE
Update strings.xml

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -64,9 +64,9 @@
     <string name="menu_refresh">Refresh</string>
     <string name="menu_preferences">Preferences</string>
     <string name="menu_auto_updates_check">Auto updates check</string>
-    <string name="menu_auto_updates_check_interval_daily">Once a day</string>
-    <string name="menu_auto_updates_check_interval_weekly">Once a week</string>
-    <string name="menu_auto_updates_check_interval_monthly">Once a month</string>
+    <string name="menu_auto_updates_check_interval_daily">Daily</string>
+    <string name="menu_auto_updates_check_interval_weekly">Weekly</string>
+    <string name="menu_auto_updates_check_interval_monthly">Monthly</string>
     <string name="menu_auto_updates_check_interval_never">Never</string>
     <string name="menu_auto_delete_updates">Delete updates when installed</string>
     <string name="menu_delete_update">Delete</string>


### PR DESCRIPTION
LOS 15.1-18.1 need change to menu_auto_updates_check_interval_x strings to the obvious simple matching word, so they actually fit in the dropdown box in portrait mode, instead of having to use landscape to see more than just "Once a " for all but "Never", especially when fonts are a little larger.