### PR TITLE
Add a basic powershell push-update script

### DIFF
--- a/push-update.ps1
+++ b/push-update.ps1
@@ -1,0 +1,28 @@
+$updates_dir = "/data/lineageos_update"
+$zip_path = $args[0]
+$zip_name = [io.path]::GetFileName($zip_path)
+$zip_hash = Get-FileHash $zip_path
+$id = $zip_hash."Hash"
+$version = Write-Output $zip_name | ForEach-Object{($_ -split "-")[1]}
+$build_date = Write-Output $zip_name | ForEach-Object{($_ -split "-")[2]} | ForEach-Object{($_ -split "_")[0]}
+$type = Write-Output $zip_name | ForEach-Object{($_ -split "-")[3]}
+$dateobject = [datetime]::parseexact($build_date, 'yyyyMMdd', $null)
+$timestamp = Get-Date $dateobject -UFormat "%s"
+$zip_stat = Get-Item -Path $zip_path
+$size = $zip_stat."Length"
+
+$zip_path_device = "$updates_dir/$zip_name"
+
+
+adb push $zip_path $zip_path_device
+adb shell chgrp cache $zip_path_device
+adb shell chmod 664 $zip_path_device
+adb shell "killall org.lineageos.updater 2>/dev/null"
+
+Write-Output "Run the below commands manually."
+Write-Output
+Write-Output "adb shell    #this will give you a root shell on the device"
+Write-Output "sqlite3 /data/data/org.lineageos.updater/databases/updates.db"
+Write-Output "INSERT INTO updates (status, path, download_id, timestamp, type, version, size) VALUES (1, '$zip_path_device', '$id', $timestamp, '$type', '$version', $size)"
+Write-Output
+Write-Output "Continue following instructions in your device's wiki page"


### PR DESCRIPTION
First time open source contributor here, long time open source consumer. So be gentle on me, please!

I recently had an issue getting the Updater app to actually download an updated package for my device, which I believe is/was due to mirror issues(?). After a month of failed download attempts, I finally decided to figure out how to update manually, within 18.1. I went out to the wiki and saw that the two options were to use the Updater app, which wasn't working, or to run a script from a Linux or Mac machine. While I am a Linux server admin, I don't have a Linux box readily available at home. After looking at the shell script, it looked simple enough to make this Linux admin consider writing a PowerShell script to be able to run this from my Windows 10 machine. I got the core parts of it completed but need help from someone that might know PowerShell a bit better than I do.

I tested this on my Pixel 2 (walleye) running LineageOS 18.1 and upgraded from the 20210622 build to the 20210720 build.

If ALL of the logic from the shell script is an absolute must before we can get this new PowerShell script merged into the repo, I can try to spend some more time figuring out the rest of the pieces. Let me know!

If we can get this merged, I'll start to explore what the next steps would be to get the wiki instructions updated to include a section for Windows users, pointing back to this script. Maybe that would help get it some more attention and get some real PowerShell devs to improve what I started here.

Anyways, I wanted to share what I came up with in case it is helpful for others. 